### PR TITLE
Fixed error newScanIssue method not defined for the interface IScannerListener

### DIFF
--- a/roboburp/RoboBurp.py
+++ b/roboburp/RoboBurp.py
@@ -45,9 +45,12 @@ class RoboBurp(object):
         try:
             user_config = self.user_config(extender_file_path, jython_jar_path, user_config_path)
             project_config = self.config_file(proxy_port, project_config_path)
+            home = expanduser("~")
+            logfile = open('{0}/.burp_log'.format(home),'wb')
+            errfile = open('{0}/.burp_err'.format(home),'wb')
             cmd = 'java -jar -Djava.awt.headless=true {0} --user-config-file={1} --config-file={2}'.format(burp_jar_path, user_config, project_config)
             logger.info('{0}'.format(cmd))
-            subprocess.Popen(cmd.split(),stdout=open(os.devnull, 'w'),stderr=subprocess.STDOUT)
+            subprocess.Popen(cmd.split(),stdout=logfile,stderr=errfile)
             time.sleep(30)
         except BaseException as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()

--- a/roboburp/roboextender.py
+++ b/roboburp/roboextender.py
@@ -144,3 +144,6 @@ class BurpExtender(IBurpExtender, IScannerListener, IProxyListener, IHttpListene
 			exc_type, exc_value, exc_traceback = sys.exc_info()
 			status = 'Failed - {0} {1}'.format(e, exc_traceback.tb_lineno)
 			self._stdout.println(status)
+
+	def newScanIssue(self, issue):
+		return


### PR DESCRIPTION
Hey, there is a small bug in the RoboBurp Library. While running burp using RoboBurp it is throwing an error `NotImplementedError`and active scan got stuck.  

![error_roboburp](https://user-images.githubusercontent.com/34654067/42371952-8ebd282e-812e-11e8-8b5a-21852bb2cd2c.png)

I made a fix for the issue.  I am tesing it now. Once it done, i will let you know. Please merge it.

